### PR TITLE
ZeraContext.json: Remove components from content sets

### DIFF
--- a/configs/ZeraContext.json
+++ b/configs/ZeraContext.json
@@ -3,477 +3,143 @@
         "ZeraActualValues": [
             {
                 "EntityId": "1040",
-                "Comment": "RMSModule",
-                "Components": [
-                    "ACT_RMSPN1",
-                    "ACT_RMSPN2",
-                    "ACT_RMSPN3",
-                    "ACT_RMSPN4",
-                    "ACT_RMSPN5",
-                    "ACT_RMSPN6",
-                    "ACT_RMSPP1",
-                    "ACT_RMSPP2",
-                    "ACT_RMSPP3"
-                ]
+                "Comment": "RMSModule"
             },
             {
                 "EntityId": "1050",
-                "Comment": "DFTModule",
-                "Components": [
-                    "ACT_DFTPN1",
-                    "ACT_DFTPN2",
-                    "ACT_DFTPN3",
-                    "ACT_DFTPN4",
-                    "ACT_DFTPN5",
-                    "ACT_DFTPN6",
-                    "ACT_DFTPN7",
-                    "ACT_DFTPN8",
-                    "ACT_DFTPP1",
-                    "ACT_DFTPP2",
-                    "ACT_DFTPP3",
-                    "ACT_RFIELD",
-                    "PAR_Interval",
-                    "PAR_RefChannel"
-               ]
+                "Comment": "DFTModule"
             },
             {
                 "EntityId": "1110",
-                "Comment": "THDNModule",
-                "Components": [
-                    "ACT_THDN1",
-                    "ACT_THDN2",
-                    "ACT_THDN3",
-                    "ACT_THDN4",
-                    "ACT_THDN5",
-                    "ACT_THDN6",
-                    "ACT_THDN7",
-                    "ACT_THDN8"
-                ]
+                "Comment": "THDNModule"
             },
             {
                 "EntityId": "1111",
-                "Comment": "THDNModule",
-                "Components": [
-                    "ACT_THDR1",
-                    "ACT_THDR2",
-                    "ACT_THDR3",
-                    "ACT_THDR4",
-                    "ACT_THDR5",
-                    "ACT_THDR6",
-                    "ACT_THDR7",
-                    "ACT_THDN8"
-                ]
+                "Comment": "THDNModule"
             },
             {
                 "EntityId": "1070",
-                "Comment": "PowerModule",
-                "Components": [
-                    "ACT_PQS1",
-                    "ACT_PQS2",
-                    "ACT_PQS3",
-                    "ACT_PQS4",
-                    "PAR_Interval",
-                    "PAR_MeasuringMode"
-                ]
+                "Comment": "PowerModule"
             },
             {
                 "EntityId": "1071",
-                "Comment": "PowerModule",
-                "Components": [
-                    "ACT_PQS1",
-                    "ACT_PQS2",
-                    "ACT_PQS3",
-                    "ACT_PQS4",
-                    "PAR_Interval",
-                    "PAR_MeasuringMode"
-                ]
+                "Comment": "PowerModule"
             },
             {
                 "EntityId": "1072",
-                "Comment": "PowerModule",
-                "Components": [
-                    "ACT_PQS1",
-                    "ACT_PQS2",
-                    "ACT_PQS3",
-                    "ACT_PQS4",
-                    "PAR_Interval",
-                    "PAR_MeasuringMode"
-                ]
+                "Comment": "PowerModule"
             },
             {
                 "EntityId": "1090",
-                "Comment": "PowerModule CED",
-                "Components": [
-                    "ACT_P1",
-                    "ACT_P2",
-                    "ACT_P3",
-                    "ACT_P4",
-                    "ACT_PM1",
-                    "ACT_PM2",
-                    "ACT_PM3",
-                    "ACT_PM4",
-                    "ACT_PP1",
-                    "ACT_PP2",
-                    "ACT_PP3",
-                    "ACT_PP4",
-                    "PAR_Interval",
-                    "PAR_MeasuringMode"
-                ]
+                "Comment": "PowerModule CED"
             },
             {
                 "EntityId": "1020",
-                "Comment": "RangeModule",
-                "Components": [
-                    "ACT_Frequency",
-                    "PAR_Channel1Range",
-                    "PAR_Channel2Range",
-                    "PAR_Channel3Range",
-                    "PAR_Channel4Range",
-                    "PAR_Channel5Range",
-                    "PAR_Channel6Range",
-                    "PAR_Channel7Range",
-                    "PAR_Channel8Range"
-                ]
+                "Comment": "RangeModule"
             },
             {
                 "EntityId": "1140",
-                "Comment": "LambdaModule",
-                "Components": [
-                    "ACT_Lambda1",
-                    "ACT_Lambda2",
-                    "ACT_Lambda3",
-                    "ACT_Lambda4"
-                ]
+                "Comment": "LambdaModule"
             }
         ],
         "ZeraHarmonics" : [
             {
                 "EntityId": "1110",
-                "Comment": "THDNModule",
-                "Components": [
-                    "ACT_THDN1",
-                    "ACT_THDN2",
-                    "ACT_THDN3",
-                    "ACT_THDN4",
-                    "ACT_THDN5",
-                    "ACT_THDN6",
-                    "ACT_THDN7",
-                    "ACT_THDN8"
-                ]
+                "Comment": "THDNModule"
             },
             {
                 "EntityId": "1060",
-                "Comment": "FFTModule",
-                "Components": [
-                    "ACT_FFT1",
-                    "ACT_FFT2",
-                    "ACT_FFT3",
-                    "ACT_FFT4",
-                    "ACT_FFT5",
-                    "ACT_FFT6",
-                    "ACT_FFT7",
-                    "ACT_FFT8"
-                ]
+                "Comment": "FFTModule"
             },
             {
                 "EntityId": "1020",
-                "Comment": "RangeModule",
-                "Components": [
-                    "ACT_Frequency",
-                    "PAR_Channel1Range",
-                    "PAR_Channel2Range",
-                    "PAR_Channel3Range",
-                    "PAR_Channel4Range",
-                    "PAR_Channel5Range",
-                    "PAR_Channel6Range",
-                    "PAR_Channel7Range",
-                    "PAR_Channel8Range"
-                ]
+                "Comment": "RangeModule"
             },
             {
-            "EntityId": "1100",
-            "Comment": "POWER3Module",
+                "EntityId": "1100",
+                "Comment": "POWER3Module"
             }
         ],
         "ZeraCurves" : [
             {
                 "EntityId": "1120",
-                "Comment": "OSCIModule",
-                "Components": [
-                    "ACT_OSCI1",
-                    "ACT_OSCI2",
-                    "ACT_OSCI3",
-                    "ACT_OSCI4",
-                    "ACT_OSCI5",
-                    "ACT_OSCI6",
-                    "ACT_OSCI7",
-                    "ACT_OSCI8"
-                ]
-
+                "Comment": "OSCIModule"
             },
             {
                 "EntityId": "1020",
-                "Comment": "RangeModule",
-                "Components": [
-                    "ACT_Frequency",
-                    "PAR_Channel1Range",
-                    "PAR_Channel2Range",
-                    "PAR_Channel3Range",
-                    "PAR_Channel4Range",
-                    "PAR_Channel5Range",
-                    "PAR_Channel6Range",
-                    "PAR_Channel7Range",
-                    "PAR_Channel8Range"
-                ]
+                "Comment": "RangeModule"
             }
         ],
         "ZeraComparison": [
             {
                 "EntityId": "1130",
-                "Comment": "SECModule",
-                "Components" : [
-                    "ACT_Status",
-                    "ACT_Result",
-                    "ACT_EnergyFinal",
-                    "PAR_DutConstant",
-                    "PAR_DutConstUnit",
-                    "PAR_MRate"
-                ]
+                "Comment": "SECModule"
             },
             {
                 "EntityId": "1131",
-                "Comment": "SECModule",
-                "Components" : [
-                    "ACT_Status",
-                    "ACT_Result",
-                    "ACT_EnergyFinal",
-                    "PAR_DutConstant",
-                    "PAR_DutConstUnit",
-                    "PAR_MRate"
-                ]
+                "Comment": "SECModule"
             },
             {
                 "EntityId": "1200",
-                "Comment": "SEMModule",
-                "Components": [
-                    "ACT_Status",
-                    "ACT_Result",
-                    "ACT_EnergyFinal",
-                    "PAR_DutConstant",
-                    "PAR_DutConstUnit",
-                    "PAR_MRate"
-                ]
+                "Comment": "SEMModule"
             },
             {
                 "EntityId": "1210",
-                "Comment": "SPMModule",
-                "Components": [
-                    "ACT_Status",
-                    "ACT_Result",
-                    "ACT_EnergyFinal",
-                    "PAR_DutConstant",
-                    "PAR_DutConstUnit",
-                    "PAR_MRate"
-                ]
+                "Comment": "SPMModule"
             },
             {
                 "EntityId": "1020",
-                "Comment": "RangeModule",
-                "Components": [
-                    "ACT_Frequency",
-                    "PAR_Channel1Range",
-                    "PAR_Channel2Range",
-                    "PAR_Channel3Range",
-                    "PAR_Channel4Range",
-                    "PAR_Channel5Range",
-                    "PAR_Channel6Range",
-                    "PAR_Channel7Range",
-                    "PAR_Channel8Range"
-                ]
+                "Comment": "RangeModule"
             },
             {
                 "EntityId": "1040",
-                "Comment": "RMSModule",
-                "Components": [
-                    "ACT_RMSPN1",
-                    "ACT_RMSPN2",
-                    "ACT_RMSPN3",
-                    "ACT_RMSPN4",
-                    "ACT_RMSPN5",
-                    "ACT_RMSPN6",
-                    "ACT_RMSPP1",
-                    "ACT_RMSPP2",
-                    "ACT_RMSPP3"
-                ]
+                "Comment": "RMSModule"
             },
             {
                 "EntityId": "1050",
-                "Comment": "DFTModule",
-                "Components": [
-                    "ACT_DFTPN1",
-                    "ACT_DFTPN2",
-                    "ACT_DFTPN3",
-                    "ACT_DFTPN4",
-                    "ACT_DFTPN5",
-                    "ACT_DFTPN6",
-                    "ACT_DFTPN7",
-                    "ACT_DFTPN8",
-                    "ACT_DFTPP1",
-                    "ACT_DFTPP2",
-                    "ACT_DFTPP3",
-                    "ACT_RFIELD",
-                    "PAR_Interval",
-                    "PAR_RefChannel"
-               ]
+                "Comment": "DFTModule"
             },
             {
                 "EntityId": "1110",
-                "Comment": "THDNModule",
-                "Components": [
-                    "ACT_THDN1",
-                    "ACT_THDN2",
-                    "ACT_THDN3",
-                    "ACT_THDN4",
-                    "ACT_THDN5",
-                    "ACT_THDN6",
-                    "ACT_THDN7",
-                    "ACT_THDN8"
-                ]
+                "Comment": "THDNModule"
             },
             {
                 "EntityId": "1111",
-                "Comment": "THDNModule",
-                "Components": [
-                    "ACT_THDR1",
-                    "ACT_THDR2",
-                    "ACT_THDR3",
-                    "ACT_THDR4",
-                    "ACT_THDR5",
-                    "ACT_THDR6",
-                    "ACT_THDR7",
-                    "ACT_THDN8"
-                ]
+                "Comment": "THDNModule"
             },
             {
                 "EntityId": "1070",
-                "Comment": "PowerModule",
-                "Components": [
-                    "ACT_PQS1",
-                    "ACT_PQS2",
-                    "ACT_PQS3",
-                    "ACT_PQS4",
-                    "PAR_Interval",
-                    "PAR_MeasuringMode"
-                ]
+                "Comment": "PowerModule"
             },
             {
                 "EntityId": "1071",
-                "Comment": "PowerModule",
-                "Components": [
-                    "ACT_PQS1",
-                    "ACT_PQS2",
-                    "ACT_PQS3",
-                    "ACT_PQS4",
-                    "PAR_Interval",
-                    "PAR_MeasuringMode"
-                ]
+                "Comment": "PowerModule"
             },
             {
                 "EntityId": "1072",
-                "Comment": "PowerModule",
-                "Components": [
-                    "ACT_PQS1",
-                    "ACT_PQS2",
-                    "ACT_PQS3",
-                    "ACT_PQS4",
-                    "PAR_Interval",
-                    "PAR_MeasuringMode"
-                ]
+                "Comment": "PowerModule"
             },
             {
                 "EntityId": "1090",
-                "Comment": "PowerModule CED",
-                "Components": [
-                    "ACT_P1",
-                    "ACT_P2",
-                    "ACT_P3",
-                    "ACT_P4",
-                    "ACT_PM1",
-                    "ACT_PM2",
-                    "ACT_PM3",
-                    "ACT_PM4",
-                    "ACT_PP1",
-                    "ACT_PP2",
-                    "ACT_PP3",
-                    "ACT_PP4",
-                    "PAR_Interval",
-                    "PAR_MeasuringMode"
-                ]
+                "Comment": "PowerModule CED"
             },
             {
                 "EntityId": "1020",
-                "Comment": "RangeModule",
-                "Components": [
-                    "ACT_Frequency",
-                    "PAR_Channel1Range",
-                    "PAR_Channel2Range",
-                    "PAR_Channel3Range",
-                    "PAR_Channel4Range",
-                    "PAR_Channel5Range",
-                    "PAR_Channel6Range",
-                    "PAR_Channel7Range",
-                    "PAR_Channel8Range"
-                ]
+                "Comment": "RangeModule"
             },
             {
                 "EntityId": "1140",
-                "Comment": "LambdaModule",
-                "Components": [
-                    "ACT_Lambda1",
-                    "ACT_Lambda2",
-                    "ACT_Lambda3",
-                    "ACT_Lambda4"
-                ]
+                "Comment": "LambdaModule"
             }
         ],
         "ZeraBurden": [
             {
                 "EntityId": "1160",
-                "Comment": "BurdenModule",
-                "Components": [
-                    "ACT_Burden1",
-                    "ACT_Burden2",
-                    "ACT_Burden3",
-                    "ACT_PFactor1",
-                    "ACT_PFactor2",
-                    "ACT_PFactor3",
-                    "ACT_Ratio1",
-                    "ACT_Ratio2",
-                    "ACT_Ratio3",
-                    "PAR_NominalBurden",
-                    "PAR_NominalRange",
-                    "PAR_WCrosssection",
-                    "PAR_Wirelength"
-                ]
+                "Comment": "BurdenModule"
             },
             {
                 "EntityId": "1161",
-                "Comment": "BurdenModule",
-                "Components": [
-                    "ACT_Burden1",
-                    "ACT_Burden2",
-                    "ACT_Burden3",
-                    "ACT_PFactor1",
-                    "ACT_PFactor2",
-                    "ACT_PFactor3",
-                    "ACT_Ratio1",
-                    "ACT_Ratio2",
-                    "ACT_Ratio3",
-                    "PAR_NominalBurden",
-                    "PAR_NominalRange",
-                    "PAR_WCrosssection",
-                    "PAR_Wirelength"
-                ]
+                "Comment": "BurdenModule"
             },
             {
                 "EntityId": "1120",
@@ -483,21 +149,7 @@
         "ZeraTransformer": [
             {
                 "EntityId": "1170",
-                "Comment": "TransformerModule",
-                "Components": [
-                    "ACT_Angle1",
-                    "ACT_Error1",
-                    "ACT_InSecondary1",
-                    "ACT_IXPrimary",
-                    "ACT_IXSecondary",
-                    "ACT_Ratio",
-                    "PAR_DutPrimary",
-                    "PAR_DutSecondary",
-                    "PAR_PrimClampPrim",
-                    "PAR_PrimClampSec",
-                    "PAR_SecClampPrim",
-                    "PAR_SecClampSec"
-                ]
+                "Comment": "TransformerModule"
             },
             {
                 "EntityId": "1120",
@@ -601,7 +253,6 @@
                 "EntityId": "1050",
                 "Comment": "DFTModule"
             },
-
             {
                 "EntityId": "1020",
                 "Comment": "RangeModule"


### PR DESCRIPTION
Rebase of branch wip_sqlAndJson should be simple: Remove the two commits (one introduce a bug / the other fixed it):

1. commit 08832714ceb97baac52ebe750f8205ec4f1053b3
Author: bhamacher <b.hamacher@zera.de>
Date:   Tue Oct 13 12:04:41 2020 +0200

    Added CustomerData context to ZeraContext.json.
    ...

2. commit d3132ea0b38ab1cdb8c219aabfd8cdda2c2b35c7
Author: bhamacher <b.hamacher@zera.de>
Date:   Fri Oct 23 08:00:11 2020 +0200

    Fixed syntax error in ZeraContext.json.
    ...

After removing them rebase should not cause conflicts