### PR TITLE
vl_databaselogger: If path does not exist, try to create it

### DIFF
--- a/vl_databaselogger.cpp
+++ b/vl_databaselogger.cpp
@@ -282,6 +282,12 @@ class DataLoggerPrivate: public QObject
         bool retVal = false;
         QFileInfo fInfo(t_dbFilePath);
 
+        // try to create path
+        if(!fInfo.absoluteDir().exists()) {
+            QDir dir;
+            dir.mkpath(fInfo.absoluteDir().path());
+        }
+
         if(fInfo.absoluteDir().exists()) {
             if(fInfo.isFile() || fInfo.exists() == false) {
                 retVal = true;


### PR DESCRIPTION
We need that when storing database on device specific path on external drives

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>