### PR TITLE
Enhance error handling on gone/overflow

### DIFF
--- a/vl_databaselogger.cpp
+++ b/vl_databaselogger.cpp
@@ -748,7 +748,7 @@ void DatabaseLogger::checkDatabaseStillValid()
 {
     QFile dbFile(m_dPtr->m_databaseFilePath);
     if(!dbFile.exists()) {
-        emit sigDatabaseError(QString("Database file %1 is gone!").arg(m_dPtr->m_databaseFilePath));
+        emit sigDatabaseError(QString("Watcher detected database file %1 is gone!").arg(m_dPtr->m_databaseFilePath));
     }
 }
 

--- a/vl_sqlitedb.h
+++ b/vl_sqlitedb.h
@@ -61,7 +61,7 @@ public slots:
     QVariant readSessionComponent(const QString &p_session, const QString &p_enity, const QString &p_component) override;
 
     bool openDatabase(const QString &t_dbPath) override;
-    bool checkAvailableSpace(const QString &t_dbPath);
+    bool isDbStillWitable(const QString &t_dbPath);
 
     void runBatchedExecution() override;
 


### PR DESCRIPTION
* Do not check db overflow on open to give user the chance to export data
* Check on all writes if db is still there and won't exceed vloume limits
  -> SQLiteDB::isDbStillWitable
* To know where database gone was detected: emit different error texts

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>