### PR TITLE
Abort open and report error, if database is readonly

### DIFF
--- a/vl_sqlitedb.cpp
+++ b/vl_sqlitedb.cpp
@@ -739,6 +739,10 @@ bool SQLiteDB::openDatabase(const QString &t_dbPath)
     QFileInfo fInfo(t_dbPath);
     bool retVal = false;
     if(fInfo.absoluteDir().exists()) {
+        if(!fInfo.isWritable()){
+            emit sigDatabaseError(QString("Database is read only"));
+            return retVal;
+        }
         QSqlError dbError;
         if(m_dPtr->m_logDB.isOpen()) {
             m_dPtr->m_logDB.close();


### PR DESCRIPTION
Opening and working on a readonly database crashes the modulemanager.
Therefore vf-logger checks if database is writeable and only proceeds in
case it is.


Signed-off-by: bhamacher <b.hamacher@zera.de>