### PR TITLE
Fix issue preventing to create new database

### DIFF
--- a/vl_sqlitedb.cpp
+++ b/vl_sqlitedb.cpp
@@ -739,7 +739,10 @@ bool SQLiteDB::openDatabase(const QString &t_dbPath)
     QFileInfo fInfo(t_dbPath);
     bool retVal = false;
     if(fInfo.absoluteDir().exists()) {
-        if(!fInfo.isWritable()){
+        // if file exists check if writable. If file
+        // does not exist it can not be writable.
+        // In this case go on and create file.
+        if(fInfo.exists() && !fInfo.isWritable()){
             emit sigDatabaseError(QString("Database is read only"));
             return retVal;
         }


### PR DESCRIPTION
If the file does not exist, the file cannot be written to.
This check prevents the creation of new databases.
If the file does not exist,
check is now ignored and new DBs can be created.

igned-off-by: bhamacher <b.hamacher@zera.de>