### PR TITLE
LoggerContentHandler: Split session set into separate method

### DIFF
--- a/vf_loggercontenthandler.h
+++ b/vf_loggercontenthandler.h
@@ -8,8 +8,9 @@ class LoggerContentHandler
 {
 public:
     virtual void setConfigFileDir(const QString &dir) = 0;
-    virtual QStringList getAvailableContentSets(const QString &session) = 0;
-    virtual QMap<int, QStringList> getEntityComponents(const QString &session, const QString &contentSetName) = 0;
+    virtual void setSession(const QString &session) = 0;
+    virtual QStringList getAvailableContentSets() = 0;
+    virtual QMap<int, QStringList> getEntityComponents(const QString &contentSetName) = 0;
 };
 
 #endif // LOGGERCONTENTHANDLER_H


### PR DESCRIPTION
* Avoids confusion: call setSession and then either getAvailableContentSets or getEntityComponents
* Implementors have to load json once only

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>