### PR TITLE
vl_databaselogger

### DIFF
--- a/lib/vl_databaselogger.cpp
+++ b/lib/vl_databaselogger.cpp
@@ -484,6 +484,8 @@ QVariant DatabaseLogger::RPC_deleteSession(QVariantMap parameters)
 QVariant DatabaseLogger::RPC_displaySessionsInfos(QVariantMap parameters)
 {
     QString session = parameters["p_session"].toString();
+    if(session == "")
+        return QVariant();
     QJsonObject json = m_database->displaySessionsInfos(session);
     QVariant retVal = json.value(session).toVariant();
     return retVal;


### PR DESCRIPTION
…is selected

This occurs when we remove Usb-stick on Export page. The table still shows transactions from the last selected session, although no session is selected