### PR TITLE
lib/rpc: Follow changes from VfCpp::VfCppRpcSimplified

### DIFF
--- a/lib/rpc/rpcdeletesession.cpp
+++ b/lib/rpc/rpcdeletesession.cpp
@@ -9,7 +9,7 @@ RpcDeleteSession::RpcDeleteSession(VeinEvent::EventSystem *eventSystem, int enti
 {
 }
 
-void RpcDeleteSession::callRPCFunction(const QUuid &callId, const QUuid &peerId, const QVariantMap &parameters)
+void RpcDeleteSession::callRPCFunction(const QUuid &callId, const QVariantMap &parameters)
 {
     RPC_deleteSession(callId, parameters);
 }

--- a/lib/rpc/rpcdeletesession.h
+++ b/lib/rpc/rpcdeletesession.h
@@ -9,7 +9,7 @@ class RpcDeleteSession : public VfCpp::VfCppRpcSimplified
 public:
     RpcDeleteSession(VeinEvent::EventSystem *eventSystem, int entityId, std::shared_ptr<VeinLogger::DatabaseCommandInterface> dbCmdInterface);
 private slots:
-    void callRPCFunction(const QUuid &callId, const QUuid &peerId, const QVariantMap &parameters) override;
+    void callRPCFunction(const QUuid &callId, const QVariantMap &parameters) override;
 private:
     void RPC_deleteSession(QUuid callId, QVariantMap parameters);
     std::shared_ptr<VeinLogger::DatabaseCommandInterface> m_dbCmdInterface = nullptr;

--- a/lib/rpc/rpcdeletetransaction.cpp
+++ b/lib/rpc/rpcdeletetransaction.cpp
@@ -10,7 +10,7 @@ RpcDeleteTransaction::RpcDeleteTransaction(VeinEvent::EventSystem *eventSystem, 
 {
 }
 
-void RpcDeleteTransaction::callRPCFunction(const QUuid &callId, const QUuid &peerId, const QVariantMap &parameters)
+void RpcDeleteTransaction::callRPCFunction(const QUuid &callId, const QVariantMap &parameters)
 {
     RPC_deleteTransaction(callId, parameters);
 }

--- a/lib/rpc/rpcdeletetransaction.h
+++ b/lib/rpc/rpcdeletetransaction.h
@@ -9,7 +9,7 @@ class RpcDeleteTransaction : public VfCpp::VfCppRpcSimplified
 public:
     RpcDeleteTransaction(VeinEvent::EventSystem *eventSystem, int entityId, std::shared_ptr<VeinLogger::DatabaseCommandInterface> dbCmdInterface);
 private slots:
-    void callRPCFunction(const QUuid &callId, const QUuid &peerId, const QVariantMap &parameters) override;
+    void callRPCFunction(const QUuid &callId, const QVariantMap &parameters) override;
 private:
     void RPC_deleteTransaction(QUuid callId, QVariantMap parameters);
     std::shared_ptr<VeinLogger::DatabaseCommandInterface> m_dbCmdInterface = nullptr;

--- a/lib/rpc/rpcdisplayactualvalues.cpp
+++ b/lib/rpc/rpcdisplayactualvalues.cpp
@@ -9,7 +9,7 @@ RpcDisplayActualValues::RpcDisplayActualValues(VeinEvent::EventSystem *eventSyst
 {
 }
 
-void RpcDisplayActualValues::callRPCFunction(const QUuid &callId, const QUuid &peerId, const QVariantMap &parameters)
+void RpcDisplayActualValues::callRPCFunction(const QUuid &callId, const QVariantMap &parameters)
 {
     RPC_displayActualValues(callId, parameters);
 }

--- a/lib/rpc/rpcdisplayactualvalues.h
+++ b/lib/rpc/rpcdisplayactualvalues.h
@@ -9,7 +9,7 @@ class RpcDisplayActualValues : public VfCpp::VfCppRpcSimplified
 public:
     RpcDisplayActualValues(VeinEvent::EventSystem *eventSystem, int entityId, std::shared_ptr<VeinLogger::DatabaseCommandInterface> dbCmdInterface);
 private slots:
-    void callRPCFunction(const QUuid &callId, const QUuid &peerId, const QVariantMap &parameters) override;
+    void callRPCFunction(const QUuid &callId, const QVariantMap &parameters) override;
 private:
     void RPC_displayActualValues(QUuid callId, QVariantMap parameters);
     std::shared_ptr<VeinLogger::DatabaseCommandInterface> m_dbCmdInterface = nullptr;

--- a/lib/rpc/rpcdisplaysessionsinfos.cpp
+++ b/lib/rpc/rpcdisplaysessionsinfos.cpp
@@ -9,7 +9,7 @@ RpcDisplaySessionsInfos::RpcDisplaySessionsInfos(VeinEvent::EventSystem *eventSy
 {
 }
 
-void RpcDisplaySessionsInfos::callRPCFunction(const QUuid &callId, const QUuid &peerId, const QVariantMap &parameters)
+void RpcDisplaySessionsInfos::callRPCFunction(const QUuid &callId, const QVariantMap &parameters)
 {
     RPC_displaySessionsInfos(callId, parameters);
 }

--- a/lib/rpc/rpcdisplaysessionsinfos.h
+++ b/lib/rpc/rpcdisplaysessionsinfos.h
@@ -9,7 +9,7 @@ class RpcDisplaySessionsInfos : public VfCpp::VfCppRpcSimplified
 public:
     RpcDisplaySessionsInfos(VeinEvent::EventSystem *eventSystem, int entityId, std::shared_ptr<VeinLogger::DatabaseCommandInterface> dbCmdInterface);
 private slots:
-    void callRPCFunction(const QUuid &callId, const QUuid &peerId, const QVariantMap &parameters) override;
+    void callRPCFunction(const QUuid &callId, const QVariantMap &parameters) override;
 private:
     void RPC_displaySessionsInfos(QUuid callId, QVariantMap parameters);
     std::shared_ptr<VeinLogger::DatabaseCommandInterface> m_dbCmdInterface = nullptr;

--- a/lib/rpc/rpclistallsessions.cpp
+++ b/lib/rpc/rpclistallsessions.cpp
@@ -9,7 +9,7 @@ RpcListAllSessions::RpcListAllSessions(VeinEvent::EventSystem *eventSystem, int 
 {
 }
 
-void RpcListAllSessions::callRPCFunction(const QUuid &callId, const QUuid &peerId, const QVariantMap &parameters)
+void RpcListAllSessions::callRPCFunction(const QUuid &callId, const QVariantMap &parameters)
 {
     RPC_listAllSessions(callId);
 }

--- a/lib/rpc/rpclistallsessions.h
+++ b/lib/rpc/rpclistallsessions.h
@@ -9,7 +9,7 @@ class RpcListAllSessions : public VfCpp::VfCppRpcSimplified
 public:
     RpcListAllSessions(VeinEvent::EventSystem *eventSystem, int entityId, std::shared_ptr<VeinLogger::DatabaseCommandInterface> dbCmdInterface);
 private slots:
-    void callRPCFunction(const QUuid &callId, const QUuid &peerId, const QVariantMap &parameters) override;
+    void callRPCFunction(const QUuid &callId, const QVariantMap &parameters) override;
 private:
     void RPC_listAllSessions(QUuid callId);
     std::shared_ptr<VeinLogger::DatabaseCommandInterface> m_dbCmdInterface = nullptr;


### PR DESCRIPTION
PeerId not sent to RPC function - not needed