### PR TITLE
testloggerdb.cpp: To be close to production behavior - do not delete …

### DIFF
--- a/testlib/testloggerdb.cpp
+++ b/testlib/testloggerdb.cpp
@@ -23,7 +23,6 @@ TestLoggerDB::TestLoggerDB(TestDbAddSignaller *testSignaller) :
 
 TestLoggerDB::~TestLoggerDB()
 {
-    deleteDbFile();
     if(m_instance != this)
         qFatal("Seems another instance was created!");
     m_instance = nullptr;


### PR DESCRIPTION
…DB file on destructor

The users of testloggerdb are responsible to do cleanup.